### PR TITLE
Update build.sh

### DIFF
--- a/azure-iot-sdks/c/build_all/linux/build.sh
+++ b/azure-iot-sdks/c/build_all/linux/build.sh
@@ -10,7 +10,7 @@ log_dir=$build_root
 run_e2e_tests=OFF
 run_longhaul_tests=OFF
 build_amqp=ON
-build_http=OFF
+build_http=ON
 build_mqtt=OFF
 skip_unittests=ON
 


### PR DESCRIPTION
Set build_http flag to ON to be in sync with build.sh in azure-iot-sdks repo.